### PR TITLE
easier noob friendly migration from Jet 0.x

### DIFF
--- a/migration-from-jet-0.x.md
+++ b/migration-from-jet-0.x.md
@@ -2,34 +2,30 @@
 
 ## Toolchain and App
 
-* You need to add _webpack.config.js_ and package.json similar to [https://github.com/webix-hub/jet-start](https://github.com/webix-hub/jet-start) 
-
-If you already have _package.json_ in your project, just add the missed dependencies.
-
+* Setup [wjet](https://webix.gitbook.io/webix-jet/part-iii-practical-tasks/wjet-utility-for-faster-prototyping) tool from the link.
+* Create new `webix-jet` app using:  
 ```text
-npm install --save-dev wjet babel-core babel-loader babel-preset-env css-loader file-loader less less-loader url-loader webpack webpack-dev-server extract-text-webpack-plugin
-npm install webix-jet
-
-//or
-
-yarn add -D wjet babel-core babel-loader babel-preset-env css-loader file-loader less less-loader url-loader webpack webpack-dev-server extract-text-webpack-plugin
-yarn add webix-jet
+mkdir new-app // this will be your new application folder when migration is finished.
+cd new-app
+wjet init
+npm install
 ```
-
-* create folder sources and move all dev files there \( _app.js_, _models/_, _views/_, _helpers/_, etc. \)
-* in _webpack.config.json_ change the entry field to the main file of your app \(`entry: "sources/app.js"`\)
-* update app.js similar to [https://github.com/webix-hub/jet-start/blob/master/sources/myapp.js](https://github.com/webix-hub/jet-start/blob/master/sources/myapp.js)
-  * import JetApp
-  * replace `core.create` with `new JetApp`
-  * remove `view.use` commands if any
-  * add `app.render()` call
+* (In your original app) create folder sources and move all dev files there \( _app.js_, _models/_, _views/_, _helpers/_, etc. \)
+* Copy the `app.js` file from `new-app` you created above to the `sources` folder. If you have any custom code in your original `app.js` then copy that in newer `app.js` too.
+* Copy over `sources` folder to the `new-app`.
+* Make sure in `new-app`, you have a locales folder with you localization files. Like [this repo](https://github.com/webix-hub/jet-start/tree/master/sources/locales)
 * run the app 
 
 ```text
+cd new-app
 npm start
 ```
 
 * open app at _localhost:8080_
+
+## Troubleshooting
+* If you get `can not resolve` error in webpack make sure you add the alias and path to that lib in webpack.config.js. [docs](https://webpack.js.org/configuration/resolve/)
+* If something else then use this [repo](https://github.com/webix-hub/jet-start) as base for migration and replace the sources folder as above.
 
 ## Migrating views
 


### PR DESCRIPTION
The migration procedure did not work for me. A lot of things were missing too such as you need to have `locales` folder with one (empty) `en.js` file to start the webpack server. Also require.js alias thing too.